### PR TITLE
Multiple code improvements - squid:S1905, squid:S2131, squid:S1854, squid:S1481

### DIFF
--- a/src/main/java/org/bytedeco/procamtracker/Chronometer.java
+++ b/src/main/java/org/bytedeco/procamtracker/Chronometer.java
@@ -94,13 +94,13 @@ public class Chronometer {
         chronoGraphics.setFont(bigFont);
         int x = (int)((roi.width -bounds.getWidth ())/2 - bounds.getX()),
             y = (int)((roi.height-bounds.getHeight())/2 - bounds.getY());
-        chronoGraphics.drawString(""+minutes,  x, y); x+=bigFontMetrics.stringWidth("0");
+        chronoGraphics.drawString(Long.toString(minutes),  x, y); x+=bigFontMetrics.stringWidth("0");
         chronoGraphics.drawString("′",  x, y);        x+=bigFontMetrics.stringWidth("′");
         chronoGraphics.drawString((seconds < 10 ?
                           "0" : "") + seconds, x, y); x+=bigFontMetrics.stringWidth("00");
         chronoGraphics.drawString("″",  x, y);        x+=bigFontMetrics.stringWidth("″");
         chronoGraphics.setFont(smallFont);
-        chronoGraphics.drawString(""+deciseconds, x, y);
+        chronoGraphics.drawString(Long.toString(deciseconds), x, y);
         if (roi.x < 0) {
             roi.x += image.width();
         }

--- a/src/main/java/org/bytedeco/procamtracker/MainFrame.java
+++ b/src/main/java/org/bytedeco/procamtracker/MainFrame.java
@@ -958,7 +958,6 @@ public class MainFrame extends javax.swing.JFrame implements
                     if (!myDirectory.isDirectory()) {
                         myDirectory = myDirectory.getParentFile();
                     }
-                    String path = myDirectory.getAbsolutePath();
 
                     String lafClassName = UIManager.getSystemLookAndFeelClassName();
                     ArrayList<String> otherArgs = new ArrayList<String>();

--- a/src/main/java/org/bytedeco/procamtracker/TrackingWorker.java
+++ b/src/main/java/org/bytedeco/procamtracker/TrackingWorker.java
@@ -497,7 +497,7 @@ public class TrackingWorker extends SwingWorker {
         }
         String infoLogString = "initial a = (";
         for (int i = 1; i < gainAmbientLight.length; i++) {
-            infoLogString += (float)gainAmbientLight[i];
+            infoLogString += Float.toString((float)gainAmbientLight[i]);
             if (i < gainAmbientLight.length-1) {
                 infoLogString += ", ";
             }
@@ -826,8 +826,8 @@ public class TrackingWorker extends SwingWorker {
                           "pyramidLevel  averageTime (ms)  averageIterations\n" +
                           "-------------------------------------------------\n";
         for (int i = 0; i < iterationTime.length; i++) {
-            double meanTime   = (double)iterationTime[i]/iterationCount[i];
-            double sqmeanTime = (double)iterationTime2[i]/iterationCount[i];
+            double meanTime   = iterationTime[i]/iterationCount[i];
+            double sqmeanTime = iterationTime2[i]/iterationCount[i];
             double meanIter   = (double)iterationCount[i]/framesCount;
             double sqmeanIter = (double)iterationCount2[i]/framesCount;
 
@@ -837,8 +837,8 @@ public class TrackingWorker extends SwingWorker {
             totalIteratingTime  += iterationTime [i];
             totalIterationCount += iterationCount[i];
         }
-        double meanTime   = (double)totalIteratingTime  /framesCount;
-        double sqmeanTime = (double)totalIteratingTime2 /framesCount;
+        double meanTime   = totalIteratingTime  /framesCount;
+        double sqmeanTime = totalIteratingTime2 /framesCount;
         double meanIter   = (double)totalIterationCount /framesCount;
         double sqmeanIter = (double)totalIterationCount2/framesCount;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1905 - Redundant casts should not be used.
squid:S2131 - Primitives should not be boxed just for "String" conversion.
squid:S1854 - Dead stores should be removed.
squid:S1481 - Unused local variables should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1905
https://dev.eclipse.org/sonar/rules/show/squid:S2131
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1481
Please let me know if you have any questions.
George Kankava
