### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/org/bytedeco/procamtracker/Chronometer.java
+++ b/src/main/java/org/bytedeco/procamtracker/Chronometer.java
@@ -38,6 +38,15 @@ import static org.bytedeco.javacpp.opencv_core.*;
  * @author Samuel Audet
  */
 public class Chronometer {
+    private Rectangle roi;
+    private long startTime;
+    private OpenCVFrameConverter converter;
+    private BufferedImage chronoImage;
+    private Graphics2D chronoGraphics;
+    private Font bigFont, smallFont;
+    private FontMetrics bigFontMetrics;
+    private Rectangle2D bounds;
+
     Chronometer(Rectangle roi, IplImage image) {
         this(roi, image, -1);
     }
@@ -68,15 +77,6 @@ public class Chronometer {
         chronoGraphics.setColor(Color.BLACK);
         chronoGraphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
     }
-
-    private Rectangle roi;
-    private long startTime;
-    private OpenCVFrameConverter converter;
-    private BufferedImage chronoImage;
-    private Graphics2D chronoGraphics;
-    private Font bigFont, smallFont;
-    private FontMetrics bigFontMetrics;
-    private Rectangle2D bounds;
 
     public void draw(IplImage image) {
         long time;

--- a/src/main/java/org/bytedeco/procamtracker/CleanBeanNode.java
+++ b/src/main/java/org/bytedeco/procamtracker/CleanBeanNode.java
@@ -35,6 +35,8 @@ import org.openide.nodes.PropertySupport;
  * @author Samuel Audet
  */
 public class CleanBeanNode<T> extends BeanNode<T> {
+    boolean renameable = true;
+
     public CleanBeanNode(T o,
             final HashMap<String, Class<? extends PropertyEditor>> editors,
             String displayName) throws IntrospectionException {
@@ -71,8 +73,6 @@ public class CleanBeanNode<T> extends BeanNode<T> {
             renameable = false;
         }
     }
-
-    boolean renameable = true;
 
     @Override public boolean canCopy() {
         return false;


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
This pull request removes 50 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava
