### PR TITLE
squid:S1132 - Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/src/main/java/org/bytedeco/procamtracker/CleanBeanNode.java
+++ b/src/main/java/org/bytedeco/procamtracker/CleanBeanNode.java
@@ -59,11 +59,11 @@ public class CleanBeanNode<T> extends BeanNode<T> {
                     ((PropertySupport.Reflection<?>)p).setPropertyEditorClass(c);
                 }
             }
-            if (p.getName().equals("beanContext") || p.getName().equals("beanContextChildPeer") ||
-                    p.getName().equals("beanContextPeer") || p.getName().equals("class") ||
-                    p.getName().equals("delegated") || p.getName().equals("designTime") ||
-                    p.getName().equals("empty") || p.getName().equals("locale") ||
-                    p.getName().equals("serializing")) {
+            if ("beanContext".equals(p.getName()) || "beanContextChildPeer".equals(p.getName()) ||
+                    "beanContextPeer".equals(p.getName()) || "class".equals(p.getName()) ||
+                    "delegated".equals(p.getName()) || "designTime".equals(p.getName()) ||
+                    "empty".equals(p.getName()) || "locale".equals(p.getName()) ||
+                    "serializing".equals(p.getName())) {
                 p.setHidden(true);
             }
         }

--- a/src/main/java/org/bytedeco/procamtracker/MainFrame.java
+++ b/src/main/java/org/bytedeco/procamtracker/MainFrame.java
@@ -259,7 +259,7 @@ public class MainFrame extends javax.swing.JFrame implements
     }
 
     public void propertyChange(PropertyChangeEvent evt) {
-        if (evt.getSource() == trackingWorker && evt.getPropertyName().equals("progress")) {
+        if (evt.getSource() == trackingWorker && "progress".equals(evt.getPropertyName())) {
             switch ((Integer)evt.getNewValue()) {
                 case TrackingWorker.INITIALIZING: statusLabel.setText("Initializing..."); break;
                 case TrackingWorker.TRACKING:     statusLabel.setText("Tracking...");     break;
@@ -895,8 +895,7 @@ public class MainFrame extends javax.swing.JFrame implements
         JDialog dialog = new JOptionPane(textPane, JOptionPane.PLAIN_MESSAGE).
                 createDialog(this, "About");
 
-        if (UIManager.getLookAndFeel().getClass().getName()
-                .equals("com.sun.java.swing.plaf.gtk.GTKLookAndFeel")) {
+        if ("com.sun.java.swing.plaf.gtk.GTKLookAndFeel".equals(UIManager.getLookAndFeel().getClass().getName())) {
             // under GTK, frameBackground is white, but rootPane color is OK...
             // but under Windows, the rootPane's color is funny...
             Color c = dialog.getRootPane().getBackground();
@@ -962,7 +961,7 @@ public class MainFrame extends javax.swing.JFrame implements
                     String lafClassName = UIManager.getSystemLookAndFeelClassName();
                     ArrayList<String> otherArgs = new ArrayList<String>();
                     for (int i = 0; i < args.length; i++) {
-                        if (args[i].equals("--laf") && i+1 < args.length) {
+                        if ("--laf".equals(args[i]) && i+1 < args.length) {
                             lafClassName = args[i+1];
                             i++;
                         } else {


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1132 -  Strings literals should be placed on the left side when checking for equality.
This pull request removes technical debt of 120 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1132
Please let me know if you have any questions.
George Kankava
