### PR TITLE
squid:S1168 - Empty arrays and collections should be returned instead of null

### DIFF
--- a/src/main/java/org/bytedeco/procamtracker/CleanBeanNode.java
+++ b/src/main/java/org/bytedeco/procamtracker/CleanBeanNode.java
@@ -85,7 +85,7 @@ public class CleanBeanNode<T> extends BeanNode<T> {
         if (o instanceof ActionableBean) {
             return ((ActionableBean)o).actions();
         } else {
-            return null;
+            return new Action[] {};
         }
     }
 

--- a/src/main/java/org/bytedeco/procamtracker/DoubleArrayEditor.java
+++ b/src/main/java/org/bytedeco/procamtracker/DoubleArrayEditor.java
@@ -42,7 +42,7 @@ public class DoubleArrayEditor extends StringArrayEditor {
 
     public static String[] doublesToStrings(double[] doubles) {
         if (doubles == null) {
-            return null;
+            return new String[] {};
         }
         String[] strings = new String[doubles.length];
         for (int i = 0; i < doubles.length; i++) {
@@ -53,7 +53,7 @@ public class DoubleArrayEditor extends StringArrayEditor {
 
     public static double[] stringsToDoubles(String[] strings) {
         if (strings == null) {
-            return null;
+            return new double[] {};
         }
         double[] doubles = new double[strings.length];
         for (int i = 0; i < strings.length; i++) {

--- a/src/main/java/org/bytedeco/procamtracker/RealityAugmentor.java
+++ b/src/main/java/org/bytedeco/procamtracker/RealityAugmentor.java
@@ -625,7 +625,7 @@ public class RealityAugmentor {
         if (markersin == null || markersin.length == 0) {
 //            throw new Exception("Error: MarkerDetector detected no markers in \"" +
 //                    settings.textureImageFile + "\".");
-            return null;
+            return new double[] {};
         }
         MarkedPlane markedPlane = new MarkedPlane(textureImage.width(), textureImage.height(), markersin, 1);
 
@@ -634,7 +634,7 @@ public class RealityAugmentor {
         if (markersout == null || markersout.length == 0 ||
                 markedPlane.getTotalWarp(markersout, tempH, true) == Double.POSITIVE_INFINITY) {
 //            throw new Exception("Error: MarkerDetector failed to match markers in the grabbed image.");
-            return null;
+            return new double[] {};
         }
         dstPts.put(0.0, 0.0,  textureImage.width(), 0.0,
                 textureImage.width(), textureImage.height(),  0.0, textureImage.height());


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1168 - Empty arrays and collections should be returned instead of null.
This pull request removes 150 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1168
Please let me know if you have any questions.
George Kankava
