### PR TITLE
squid:S1181 - Throwable and Error should not be caught

### DIFF
--- a/src/main/java/org/bytedeco/procamtracker/RealityAugmentor.java
+++ b/src/main/java/org/bytedeco/procamtracker/RealityAugmentor.java
@@ -434,7 +434,7 @@ public class RealityAugmentor {
             }
             try {
                 videoToProject = new FFmpegFrameGrabber(virtualSettings.projectorVideoFile);
-            } catch (Throwable t) {
+            } catch (Exception e) {
                 videoToProject = new OpenCVFrameGrabber(virtualSettings.projectorVideoFile);
             }
             if (videoToProject != null) {

--- a/src/main/java/org/bytedeco/procamtracker/TrackingWorker.java
+++ b/src/main/java/org/bytedeco/procamtracker/TrackingWorker.java
@@ -1013,9 +1013,10 @@ public class TrackingWorker extends SwingWorker {
                 System.gc();
                 Pointer.deallocateReferences();
             }
-        } catch (Throwable t) {
+        } catch (Exception e) {
+            Throwable t = null;
             if (!isCancelled()) {
-                while (t.getCause() != null) { t = t.getCause(); }
+                while (e.getCause() != null) { t = e.getCause(); }
                 logger.log(Level.SEVERE, "Could not perform tracking.", t);
                 cancel(false);
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1181 - Throwable and Error should not be caught.
This pull request removes 40 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1181
Please let me know if you have any questions.
George Kankava
